### PR TITLE
Add notebook: hana_graph_sparql.ipynb for SAP HANA Knowledge Graph SPARQL QA with LangChain

### DIFF
--- a/docs/docs/integrations/graphs/hana_graph_sparql.ipynb
+++ b/docs/docs/integrations/graphs/hana_graph_sparql.ipynb
@@ -1,0 +1,686 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f46bd472-9a41-4cdd-ab40-7ebfb4e2aa87",
+   "metadata": {},
+   "source": [
+    "# SAP HANA Cloud Knowledge Graph Engine\n",
+    "\n",
+    ">[SAP HANA Cloud Knowledge Graph](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-knowledge-graph-guide/sap-hana-cloud-sap-hana-database-knowledge-graph-engine-guide) is a fully integrated knowledge graph solution within the `SAP HANA Cloud` database.\n",
+    ">\n",
+    ">This example demonstrates how to build a QA (Question-Answering) chain that queries [Resource Description Framework (RDF)](https://en.wikipedia.org/wiki/Resource_Description_Framework) data stored in an `SAP HANA Cloud` instance using the `SPARQL` query language, and returns a human-readable response.\n",
+    ">\n",
+    ">[SPARQL](https://en.wikipedia.org/wiki/SPARQL) is the standard query language for querying `RDF` graphs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d4ad465-8e62-49b5-81c7-3e98d6e85e53",
+   "metadata": {},
+   "source": [
+    "## Setup & Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a06e4c74-5818-4347-9f3d-d63202ae68e5",
+   "metadata": {},
+   "source": [
+    "**Prerequisite**:  \n",
+    "You must have an SAP HANA Cloud instance with the **triple store** feature enabled.  \n",
+    "For detailed instructions, refer to: [Enable Triple Store](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-knowledge-graph-guide/enable-triple-store)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c519a33-b21d-4a45-a6a9-b1538da40751",
+   "metadata": {},
+   "source": [
+    "To use SAP HANA Knowledge Graph Engine and/or Vector Store Engine with LangChain, install the `langchain-hana` package:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d924add-3b79-4323-b9e8-f3841ffe8533",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-hana"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cc3e3fb-9fad-464e-a68a-f49cb3da31bd",
+   "metadata": {},
+   "source": [
+    "First, create a connection to your SAP HANA Cloud instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "452fedb4-e121-41bd-92de-ae211d2bf928",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "from hdbcli import dbapi\n",
+    "import os\n",
+    "\n",
+    "# Load environment variables if needed\n",
+    "load_dotenv()\n",
+    "\n",
+    "# Establish connection to SAP HANA Cloud\n",
+    "connection = dbapi.connect(\n",
+    "    address=os.environ.get(\"HANA_DB_ADDRESS\"),\n",
+    "    port=os.environ.get(\"HANA_DB_PORT\"),\n",
+    "    user=os.environ.get(\"HANA_DB_USER\"),\n",
+    "    password=os.environ.get(\"HANA_DB_PASSWORD\"),\n",
+    "    autocommit=True,\n",
+    "    sslValidateCertificate=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e51f87a-ffe1-464b-874e-297fe5dd4547",
+   "metadata": {},
+   "source": [
+    "## Example: Question Answering over a “Movies” Knowledge Graph\n",
+    "\n",
+    "Below we’ll:\n",
+    "\n",
+    "1. Instantiate the `HanaRdfGraph` pointing at our “movies” data graph and its ontology  \n",
+    "2. Wrap it in a `HanaSparqlQAChain` powered by an LLM  \n",
+    "3. Ask natural-language questions and print out the chain’s responses  \n",
+    "\n",
+    "This demonstrates how the LLM generates SPARQL under the hood, executes it against SAP HANA, and returns a human-readable answer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "adba3dd8-2786-4157-9db5-901ffa3d89d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_hana import HanaRdfGraph, HanaSparqlQAChain\n",
+    "from langchain_openai import ChatOpenAI  # or your chosen LLM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3a2e0e4c-e242-42f5-b117-83ce9db0e3a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the Knowledge Graph\n",
+    "graph_uri = \"http://kg.demo.sap.com/movies\"\n",
+    "ontology_uri = \"http://kg.demo.sap.com/movies_ontology\"\n",
+    "graph = HanaRdfGraph(\n",
+    "    connection=connection,\n",
+    "    graph_uri=graph_uri,\n",
+    "    ontology_uri=ontology_uri\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d58cabc8-3912-49d2-9296-e8d49cc3525c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize the LLM\n",
+    "llm = ChatOpenAI(model=\"gpt-4o\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e29a141d-f511-4930-8ea2-51d3b02bb5a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a SPARQL QA Chain\n",
+    "chain = HanaSparqlQAChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    verbose=True,\n",
+    "    allow_dangerous_requests=True,\n",
+    "    graph=graph)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f2f3ebe8-8ea5-4e26-b311-73c7682d3fe9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new HanaSparqlQAChain chain...\u001b[0m\n",
+      "Generated SPARQL:\n",
+      "\u001b[32;1m\u001b[1;3m```sparql\n",
+      "PREFIX kg: <http://kg.demo.sap.com/>\n",
+      "\n",
+      "SELECT ?movieTitle\n",
+      "WHERE {\n",
+      "    ?actor1 kg:name \"Harrison Ford\" .\n",
+      "    ?actor2 kg:name \"Liam Neeson\" .\n",
+      "    ?movie kg:title ?movieTitle .\n",
+      "    ?actor1 kg:acted_in ?movie .\n",
+      "    ?actor2 kg:acted_in ?movie .\n",
+      "}\n",
+      "```\u001b[0m\n",
+      "Final SPARQL:\n",
+      "\u001b[33;1m\u001b[1;3m\n",
+      "PREFIX kg: <http://kg.demo.sap.com/>\n",
+      "\n",
+      "SELECT ?movieTitle\n",
+      "\n",
+      "FROM <http://kg.demo.sap.com/movies>\n",
+      "WHERE {\n",
+      "    ?actor1 kg:name \"Harrison Ford\" .\n",
+      "    ?actor2 kg:name \"Liam Neeson\" .\n",
+      "    ?movie kg:title ?movieTitle .\n",
+      "    ?actor1 kg:acted_in ?movie .\n",
+      "    ?actor2 kg:acted_in ?movie .\n",
+      "}\n",
+      "\u001b[0m\n",
+      "Full Context:\n",
+      "\u001b[32;1m\u001b[1;3mmovieTitle\n",
+      "K-19: The Widowmaker\n",
+      "Anchorman 2: The Legend Continues\n",
+      "\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "Harrison Ford and Liam Neeson both appeared in the movie \"K-19: The Widowmaker.\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = chain.invoke(\"In which movies did Harrison Ford and Liam Neeson play in together\")\n",
+    "print(output['result'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "09f0f6e6-b8f3-4d65-a768-d422869d8cb4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "\u001b[1m> Entering new HanaSparqlQAChain chain...\u001b[0m\n",
+      "Generated SPARQL:\n",
+      "\u001b[32;1m\u001b[1;3m```sparql\n",
+      "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "PREFIX : <http://kg.demo.sap.com/>\n",
+      "\n",
+      "SELECT ?title ?budget ?directorName\n",
+      "WHERE {\n",
+      "    ?movie a :Movie ;\n",
+      "           :title ?title ;\n",
+      "           :budget ?budget .\n",
+      "    ?director a :Director ;\n",
+      "              :directed ?movie ;\n",
+      "              :name ?directorName .\n",
+      "}\n",
+      "ORDER BY DESC(?budget)\n",
+      "LIMIT 3\n",
+      "```\u001b[0m\n",
+      "Final SPARQL:\n",
+      "\u001b[33;1m\u001b[1;3m\n",
+      "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n",
+      "PREFIX : <http://kg.demo.sap.com/>\n",
+      "\n",
+      "SELECT ?title ?budget ?directorName\n",
+      "\n",
+      "FROM <http://kg.demo.sap.com/movies>\n",
+      "WHERE {\n",
+      "    ?movie a :Movie ;\n",
+      "           :title ?title ;\n",
+      "           :budget ?budget .\n",
+      "    ?director a :Director ;\n",
+      "              :directed ?movie ;\n",
+      "              :name ?directorName .\n",
+      "}\n",
+      "ORDER BY DESC(?budget)\n",
+      "LIMIT 3\n",
+      "\u001b[0m\n",
+      "Full Context:\n",
+      "\u001b[32;1m\u001b[1;3mtitle,budget,directorName\n",
+      "Pirates of the Caribbean: On Stranger Tides,380000000,Rob Marshall\n",
+      "Pirates of the Caribbean: At World's End,300000000,Gore Verbinski\n",
+      "Avengers: Age of Ultron,280000000,Joss Whedon\n",
+      "\u001b[0m\n",
+      "\n",
+      "\u001b[1m> Finished chain.\u001b[0m\n",
+      "Based on the information provided, the three movies with the highest budgets are as follows:\n",
+      "\n",
+      "1. \"Pirates of the Caribbean: On Stranger Tides\" with a budget of $380,000,000, directed by Rob Marshall.\n",
+      "2. \"Pirates of the Caribbean: At World's End\" with a budget of $300,000,000, directed by Gore Verbinski.\n",
+      "3. \"Avengers: Age of Ultron\" with a budget of $280,000,000, directed by Joss Whedon.\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = chain.invoke(\"What are the three movies with the highest budgets, their titles, and the names of the directors who directed them?\")\n",
+    "print(output['result'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a40a3f21-e26a-4a9e-9f1f-47435db3d14d",
+   "metadata": {},
+   "source": [
+    "### What’s happening under the hood?\n",
+    "\n",
+    "1. **SPARQL Generation**  \n",
+    "   The chain invokes the LLM with your Turtle-formatted ontology (`graph.get_schema`) and the user’s question using the `SPARQL_GENERATION_SELECT_PROMPT`. The LLM then emits a valid `SELECT` query tailored to your schema.\n",
+    "\n",
+    "2. **Pre-processing & Execution**  \n",
+    "   - **Extract & clean**: Pull the raw SPARQL text out of the LLM’s response.  \n",
+    "   - **Inject graph context**: Add `FROM <graph_uri>` if it’s missing and ensure common prefixes (`rdf:`, `rdfs:`, `owl:`, `xsd:`) are declared.  \n",
+    "   - **Run on HANA**: Execute the finalized query via `HanaRdfGraph.query()` over your named graph.\n",
+    "\n",
+    "3. **Answer Formulation**  \n",
+    "   The returned CSV (or Turtle) results feed into the LLM again—this time with the `SPARQL_QA_PROMPT`. The LLM produces a concise, human-readable answer strictly based on the retrieved data, without hallucination.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b24edcc5-9680-447f-a8b7-f380b8b554de",
+   "metadata": {},
+   "source": [
+    "## Initialize the `HanaRdfGraph`\n",
+    "\n",
+    "To power the QA chain, you first need a `HanaRdfGraph` instance that:\n",
+    "\n",
+    "1. Loads your ontology schema (in Turtle)  \n",
+    "2. Executes SPARQL queries against your SAP HANA Cloud data graph  \n",
+    "\n",
+    "The constructor requires:\n",
+    "\n",
+    "- **`connection`**: an active `hdbcli.dbapi.connect(...)` instance  \n",
+    "- **`graph_uri`**: the named graph (or `\"DEFAULT\"`) where your RDF data lives  \n",
+    "- **One of**:  \n",
+    "  - **`ontology_query`**: a SPARQL CONSTRUCT to extract schema triples  \n",
+    "  - **`ontology_uri`**: a hosted ontology graph URI  \n",
+    "  - **`ontology_local_file`** + **`ontology_local_file_format`**: a local Turtle/RDF file  \n",
+    "  - **`auto_extract_ontology=True`** (not recommended for production—see note)\n",
+    "\n",
+    "### `graph_uri` vs. Ontology\n",
+    "- **`graph_uri`**:  \n",
+    "  The named graph in your SAP HANA Cloud instance that contains your instance data (sometimes 100k+ triples).\n",
+    "  If `None` or `\"DEFAULT\"` is provided, the default graph is used.  \n",
+    "  ➔ More details: [Default Graph and Named Graphs](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-knowledge-graph-guide/default-graph-and-named-graphs)\n",
+    "- **Ontology**: a lean schema (typically ~50-100 triples) describing classes, properties, domains, ranges, labels, comments, and subclass relationships. The ontology guides SPARQL generation and result interpretation.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e414bfa-7c15-405c-a348-f90f53376c4a",
+   "metadata": {},
+   "source": [
+    "1. **Custom SPARQL CONSTRUCT query** (`ontology_query`): Use a custom `CONSTRUCT` query to selectively extract schema triples.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "398910fb-75d3-4790-a2d3-9f8945150129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "custom_construct = \"\"\"\n",
+    "CONSTRUCT {\n",
+    "  ?s ?p ?o .\n",
+    "}\n",
+    "FROM <http://kg.demo.sap.com/movies_ontology>\n",
+    "WHERE {\n",
+    "    ?s ?p ?o .\n",
+    "}\n",
+    "\"\"\"\n",
+    "graph = HanaRdfGraph(\n",
+    " connection=connection,\n",
+    " graph_uri=\"http://kg.demo.sap.com/movies\",\n",
+    " ontology_query=custom_construct\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faf10bd1-919b-4ffe-80e2-4ec19e40c33c",
+   "metadata": {},
+   "source": [
+    "2. **Remote ontology URI** (`ontology_uri`): Load the schema directly from a hosted graph URI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0e1ea4ce-280a-4510-a0b3-30cb2a0565a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = HanaRdfGraph(\n",
+    " connection=connection,\n",
+    " graph_uri=\"http://kg.demo.sap.com/movies\",\n",
+    " ontology_uri=\"http://kg.demo.sap.com/movies_ontology\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f59811e-abee-4e2e-8a12-0fc692fdde1d",
+   "metadata": {},
+   "source": [
+    "3. **Local RDF file** (`ontology_local_file` + `ontology_local_file_format`): Load the schema from a local RDF ontology file. Supported RDF formats are `Turtle`, `RDF/XML`, `JSON-LD`, `N-Triples`, `Notation-3`, `Trig`, `Trix`, `N-Quads`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "48de41a6-cb4e-4b30-b59a-88b2f2be9428",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = HanaRdfGraph(\n",
+    " connection=connection,\n",
+    " graph_uri=\"http://kg.demo.sap.com/movies\",\n",
+    " ontology_local_file=\"movies_ontology.ttl\",\n",
+    " ontology_local_file_format=\"turtle\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80d1f677-d23f-4ca2-8644-26a6dbd84dd4",
+   "metadata": {},
+   "source": [
+    "4. **Auto-extract ontology** (`auto_extract_ontology=True`): Infer schema information directly from your instance data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "4d48cd2c-24ca-42e8-8d6b-7f5f478ec778",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph_with_auto_extracted_ontology = HanaRdfGraph(\n",
+    " connection=connection,\n",
+    " graph_uri=\"http://kg.demo.sap.com/movies\",\n",
+    " auto_extract_ontology=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f8afc0b-33fe-4950-98aa-b283d32396b2",
+   "metadata": {},
+   "source": [
+    "> **Note**: Auto-extraction is **not** recommended for production—it omits important triples like `rdfs:label`, `rdfs:comment`, and `rdfs:subClassOf` in general."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7539bf25-df8e-4404-9874-00ecc0543c9f",
+   "metadata": {},
+   "source": [
+    "## Executing SPARQL Queries\n",
+    "\n",
+    "You can use the `query()` method to execute arbitrary SPARQL queries (`SELECT`, `ASK`, `CONSTRUCT`, etc.) on the data graph.  \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7019808a-b4b5-4771-bad5-d32e67d30ac6",
+   "metadata": {},
+   "source": [
+    "The following query retrieves the top 10 movies with the highest number of contributors:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d0205723-2f46-4a6a-b65c-e9a7dcb0f3ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "movieTitle,contributorCount\n",
+      "Jurassic World,430\n",
+      "15 Minutes,329\n",
+      "The Wolf of Wall Street,239\n",
+      "\"Monsters, Inc.\",232\n",
+      "The Day After Tomorrow,223\n",
+      "The Core,219\n",
+      "The Dark Knight Rises,210\n",
+      "The X Files: I Want to Believe,195\n",
+      "V for Vendetta,190\n",
+      "The Chronicles of Riddick,186\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"\"\"\n",
+    "PREFIX kg: <http://kg.demo.sap.com/>\n",
+    "SELECT ?movieTitle (COUNT(?crewmember) AS ?contributorCount)\n",
+    "\n",
+    "FROM <http://kg.demo.sap.com/movies>\n",
+    "WHERE {\n",
+    "    ?crewmember kg:contributed_to ?movie .\n",
+    "    ?movie kg:title ?movieTitle .\n",
+    "}\n",
+    "GROUP BY ?movieTitle\n",
+    "ORDER BY DESC(?contributorCount)\n",
+    "LIMIT 10\n",
+    "\"\"\"\n",
+    "top10 = graph.query(query)\n",
+    "print(top10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b33809f5-8edd-4872-b7b1-090d7254ce9d",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "## Question Answering with `HanaSparqlQAChain`\n",
+    "\n",
+    "`HanaSparqlQAChain` ties together:\n",
+    "\n",
+    "1. **Schema-aware SPARQL generation**  \n",
+    "2. **Query execution** against SAP HANA  \n",
+    "3. **Natural-language answer formatting**\n",
+    "\n",
+    "\n",
+    "### Initialization\n",
+    "\n",
+    "You need:\n",
+    "\n",
+    "- An **LLM** to generate and interpret queries  \n",
+    "- A **`HanaRdfGraph`** (with connection, `graph_uri`, and ontology)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "56f8b48f-117f-43b9-b0dc-40a685996f04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI  # or your chosen LLM\n",
+    "llm = ChatOpenAI(model=\"gpt-4o\")\n",
+    "\n",
+    "qa_chain = HanaSparqlQAChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    graph=graph,\n",
+    "    allow_dangerous_requests=True,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2ab3fc0-40af-474d-adf7-e42078b19a35",
+   "metadata": {},
+   "source": [
+    "### Pipeline Overview\n",
+    "\n",
+    "1. **SPARQL Generation**  \n",
+    "   - Uses `SPARQL_GENERATION_SELECT_PROMPT`  \n",
+    "   - Inputs:  \n",
+    "     - `schema` (Turtle from `graph.get_schema`)  \n",
+    "     - `prompt` (user’s question)  \n",
+    "2. **Query Post-processing**  \n",
+    "   - Extracts the SPARQL code from the llm output.\n",
+    "   - Inject `FROM <graph_uri>` if missing  \n",
+    "   - Ensure required common prefixes are declared (`rdf:`, `rdfs:`, `owl:`, `xsd:`)  \n",
+    "3. **Execution**  \n",
+    "   - Calls `graph.query(generated_sparql)`  \n",
+    "4. **Answer Formulation**  \n",
+    "   - Uses `SPARQL_QA_PROMPT`  \n",
+    "   - Inputs:  \n",
+    "     - `context` (raw query results)  \n",
+    "     - `prompt` (original question)  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5c014af-71a8-4ef8-8a54-2df0d7edb8e5",
+   "metadata": {},
+   "source": [
+    "### Prompt Templates\n",
+    "\n",
+    "\n",
+    "#### \"SPARQL Generation\" prompt\n",
+    "\n",
+    "The `sparql_generation_prompt` is used to guide the LLM in generating a SPARQL query from the user question and the provided schema.\n",
+    "\n",
+    "Default template:\n",
+    "  ````python\n",
+    "  SPARQL_GENERATION_SELECT_TEMPLATE = \"\"\"Task: Generate a SPARQL SELECT statement for querying a graph database.\n",
+    "    For instance, to find all email addresses of John Doe, the following query in backticks would be suitable:\n",
+    "    ```\n",
+    "    PREFIX foaf: <http://xmlns.com/foaf/0.1/>\n",
+    "    SELECT ?email\n",
+    "    WHERE {{\n",
+    "        ?person foaf:name \"John Doe\" .\n",
+    "        ?person foaf:mbox ?email .\n",
+    "    }}\n",
+    "    ```\n",
+    "    Instructions:\n",
+    "    Use only the node types and properties provided in the schema.\n",
+    "    Do not use any node types and properties that are not explicitly provided.\n",
+    "    Include all necessary prefixes.\n",
+    "    Schema:\n",
+    "    {schema}\n",
+    "    Do not respond to any questions that ask for anything else than for you to construct a SPARQL query.\n",
+    "    Do not include any text except the SPARQL query generated.\n",
+    "    Please pay attention to providing the subject, predicate, and object in the correct order.\n",
+    "    Ensure that every variable referenced in any clause (such as SELECT, ORDER BY, GROUP BY, etc.) is explicitly defined in the WHERE clause, either by being used as a subject, predicate, or object in a triple pattern, or through a BIND statement. \n",
+    "    Do not include any variables in those clauses unless they are defined in the WHERE clause.\n",
+    "    \n",
+    "    The question is:\n",
+    "    {prompt}\"\"\"\n",
+    "    SPARQL_GENERATION_SELECT_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"schema\", \"prompt\"], template=SPARQL_GENERATION_SELECT_TEMPLATE\n",
+    "    )\n",
+    "  ````\n",
+    "\n",
+    "\n",
+    "#### Answering prompt\n",
+    "\n",
+    "The `qa_prompt` instructs the LLM to create a natural language answer based solely on the database results.\n",
+    "  \n",
+    "Default template:\n",
+    "  ````python\n",
+    "  SPARQL_QA_TEMPLATE = \"\"\"Task: Generate a natural language response from the results of a SPARQL query.\n",
+    "    You are an assistant that creates well-written and human understandable answers.\n",
+    "    The information part contains the information provided, which you can use to construct an answer.\n",
+    "    The information provided is authoritative, you must never doubt it or try to use your internal knowledge to correct it.\n",
+    "    Make your response sound like the information is coming from an AI assistant, but don't add any information. \n",
+    "    Don't use internal knowledge to answer the question, just say you don't know if no information is available.\n",
+    "    Information:\n",
+    "    {context}\n",
+    "    \n",
+    "    Question: {prompt}\n",
+    "    Helpful Answer:\"\"\"\n",
+    "    SPARQL_QA_PROMPT = PromptTemplate(\n",
+    "        input_variables=[\"context\", \"prompt\"], template=SPARQL_QA_TEMPLATE\n",
+    "    )\n",
+    "  ````"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fd5dee-047f-49d3-a2a0-050d5174a73b",
+   "metadata": {},
+   "source": [
+    "### Customizing Prompts\n",
+    "\n",
+    "You can override the defaults at initialization:\n",
+    "\n",
+    "```python\n",
+    "qa_chain = HanaSparqlQAChain.from_llm(\n",
+    "    llm=llm,\n",
+    "    graph=graph,\n",
+    "    allow_dangerous_requests=True,\n",
+    "    verbose=True,\n",
+    "    sparql_generation_prompt=YOUR_SPARQL_PROMPT,\n",
+    "    qa_prompt=YOUR_QA_PROMPT\n",
+    ")\n",
+    "```\n",
+    "\n",
+    "Or swap them afterward:\n",
+    "\n",
+    "```python\n",
+    "qa_chain.sparql_generation_chain.prompt = YOUR_SPARQL_PROMPT\n",
+    "qa_chain.qa_chain.prompt              = YOUR_QA_PROMPT\n",
+    "```\n",
+    "\n",
+    "> - `sparql_generation_prompt` must have the input variables: `[\"schema\", \"prompt\"]`\n",
+    "> - `qa_prompt` must have the input variables: `[\"context\", \"prompt\"]`"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lc3",
+   "language": "python",
+   "name": "your_env_name"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a new Jupyter notebook, `hana_graph_sparql.ipynb`, which demonstrates how to:

- Connect to SAP HANA Cloud Knowledge Graph Engine
- Initialize the HanaRdfGraph and HanaSparqlQAChain components
- Generate and execute SPARQL queries using LangChain + LLMs (e.g., GPT-4o)
- Perform question answering over RDF data with natural language input
- Customize SPARQL generation and QA prompt templates

The notebook provides a complete, well-documented example for developers working with SAP HANA Knowledge Graph and LangChain.
